### PR TITLE
Update to v2026.2.15

### DIFF
--- a/PropHunt/PropHunt.csproj
+++ b/PropHunt/PropHunt.csproj
@@ -18,8 +18,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Reactor" Version="2.5.0.ci-371" />
-        <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.697" Private="false" ExcludeAssets="runtime;native" />
+        <PackageReference Include="Reactor" Version="2.5.0-ci.371" />
+        <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.735" Private="false" ExcludeAssets="runtime;native" />
         <PackageReference Include="AmongUs.GameLibs.Steam" Version="2025.11.18" PrivateAssets="all" />
 
         <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0" PrivateAssets="all" />

--- a/PropHunt/PropHunt.csproj
+++ b/PropHunt/PropHunt.csproj
@@ -5,7 +5,7 @@
         <DebugType>embedded</DebugType>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-        <VersionPrefix>2024.11.5</VersionPrefix>
+        <VersionPrefix>2026.2.15</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
         <Description>Prop Hunt Mod</Description>
         <Authors>ugackMiner</Authors>
@@ -13,14 +13,14 @@
 
     <PropertyGroup>
         <GamePlatform Condition="'$(GamePlatform)' == ''">Steam</GamePlatform>
-        <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2024.10.29</GameVersion>
-        <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2024.10.29</GameVersion>
+        <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2025.11.18</GameVersion>
+        <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2025.11.18</GameVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Reactor" Version="2.3.1" />
+        <PackageReference Include="Reactor" Version="2.5.0.ci-371" />
         <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.697" Private="false" ExcludeAssets="runtime;native" />
-        <PackageReference Include="AmongUs.GameLibs.Steam" Version="2024.10.29" PrivateAssets="all" />
+        <PackageReference Include="AmongUs.GameLibs.Steam" Version="2025.11.18" PrivateAssets="all" />
 
         <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0" PrivateAssets="all" />
         <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.0.1" PrivateAssets="all" ExcludeAssets="runtime" />
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Deobfuscate Include="../.references/Assembly-CSharp-2024.10.29.dll" />
+        <Deobfuscate Include="../.references/Assembly-CSharp-2025.11.18.dll" />
 
         <!-- <PackageReference Include="Reactor.OxygenFilter.MSBuild" Version="0.3.0" /> -->
     </ItemGroup>

--- a/PropHunt/PropHuntPlugin.cs
+++ b/PropHunt/PropHuntPlugin.cs
@@ -11,7 +11,7 @@ using Reactor.Utilities;
 
 namespace PropHunt;
 
-[BepInPlugin("com.ugackminer.amongus.prophunt", "Prop Hunt", "v2024.11.5")]
+[BepInPlugin("com.ugackminer.amongus.prophunt", "Prop Hunt", "v2026.2.15")]
 [BepInProcess("Among Us.exe")]
 [BepInDependency(ReactorPlugin.Id)]
 public partial class PropHuntPlugin : BasePlugin

--- a/PropHunt/Settings/PropHuntPreset.cs
+++ b/PropHunt/Settings/PropHuntPreset.cs
@@ -81,12 +81,12 @@ namespace PropHunt.Settings
             presetButton.transform.localPosition = new Vector3(2.4f, -0.1f, 0);
 
             // Add interactivity to the prop button
-            presetButton.OnClick.AddListener((UnityAction)delegate {
+            presetButton.OnClick.AddListener(new System.Action(() => {
                 __instance.StandardPresetButton.SelectButton(false);
                 __instance.SecondPresetButton.SelectButton(false);
                 presetButton.SelectButton(true);
-                __instance.ClickPresetButton(propHuntRulePreset);
-            });
+                __instance.ClickPresetButton(propHuntRulePreset, false);
+            }));
 
             presetButton.OnMouseOver.AddListener((UnityAction)delegate {
                 __instance.PresetDescriptionText.text = propHuntDescription;

--- a/PropHunt/Settings/PropHuntSettings.cs
+++ b/PropHunt/Settings/PropHuntSettings.cs
@@ -90,7 +90,7 @@ namespace PropHunt.Settings
             propHuntCheckbox.OptionName = propHuntBooleanName;
             propHuntCheckbox.Type = OptionTypes.Checkbox;
             propHuntCheckbox.name = "Prop Hunt";
-            allGameList.System_Collections_IList_Add(propHuntCheckbox);
+            allGameList.Add(propHuntCheckbox);
 
             FloatGameSetting timePenaltyFloat = ScriptableObject.CreateInstance<FloatGameSetting>();
             timePenaltyFloat.Title = timePenaltyStringName;
@@ -103,7 +103,7 @@ namespace PropHunt.Settings
             timePenaltyFloat.ZeroIsInfinity = false;
             timePenaltyFloat.ValidRange = new FloatRange(0, 60);
             timePenaltyFloat.Value = PropHuntPlugin.missTimePenalty;
-            allGameList.System_Collections_IList_Add(timePenaltyFloat);
+            allGameList.Add(timePenaltyFloat);
 
 
             propHuntCategory = new RulesCategory
@@ -112,7 +112,7 @@ namespace PropHunt.Settings
                 CategoryName = propHuntStringName
             };
 
-            __instance.HideAndSeekManagerPrefab.gameSettingsList.AllCategories.System_Collections_IList_Add(propHuntCategory);
+           __instance.HideAndSeekManagerPrefab.gameSettingsList.AllCategories.Add(propHuntCategory);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Prop Hunt Logo](./Images/prophuntlogo.png)
 
-```Compatible with v2024.10.29 ```
+```Compatible with v2025.11.18 ```
 # Prop Hunt
 
 A mod for [Among Us](https://store.steampowered.com/app/945360/Among_Us/) which extends Hide and Seek into a new mode, Prop Hunt!
@@ -16,6 +16,7 @@ Prop Hunt uses the same rules and basics as Hide and Seek. Simply create a Hide 
 |-----|--------|
 | `R` | Turn into nearest task |
 | `Shift` | Move task |
+| `C` | Turn back into a crewmate |
 
 *Note: You may get stuck when moving the task. Move the task back down before moving again.*
 


### PR DESCRIPTION
# Changes
This pull request updates the mod dependencies for compatibility with Among Us v2025.11.18 and Reactor v2.5.0 and also introduces a new feature to turn back into a crewmate after turning into the prop

## Key Changes
- **Version Update**: updated the project latest game version (17.0.2 or 2025.11.18).
- **Manual Revert**: players can now press the 'C' key to transform from a prop back into a crewmate.
- **Networking**: added a new `Revert` RPC to ensure the transformation is synced across all clients.

## Files Modified
- Patches.cs: Added 'C' key input detection.
- RPCHandler.cs: Added RPC logic for reverting sprites and visibility.
- PropHuntPlugin.cs : Updated to latest among us and reactor version
- PropHunt.csproj : Updated to latest among us and reactor version
- PropHuntPresets.cs : Updated to latest among us and reactor version
- PropHuntSettings.cs : Updated to latest among us and reactor version
- README.md : Updated to latest among us and reactor version